### PR TITLE
Add "shim" config so JSPM/SystemJS loads angular first

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,12 @@
   "bugs": {
     "url": "https://github.com/angular/angular.js/issues"
   },
-  "homepage": "http://angularjs.org"
+  "homepage": "http://angularjs.org",
+  "jspm": {
+    "shim": {
+      "angular-parse-ext": {
+        "deps": ["angular"]
+      }
+    }
+  }
 }


### PR DESCRIPTION
This only affects installations done with:

jspm install npm:angular-parse-ext
